### PR TITLE
fix php8 warning

### DIFF
--- a/src/Tester/ObjectManagerTrait.php
+++ b/src/Tester/ObjectManagerTrait.php
@@ -59,7 +59,7 @@ trait ObjectManagerTrait
         }
     }
 
-    final private function clearObjectManagers(): void
+    private function clearObjectManagers(): void
     {
         foreach ($this->getObjectManagers() as $objectManager) {
             $objectManager->clear();


### PR DESCRIPTION
Fixes warning:
`Warning: Private methods cannot be final as they are never overridden by other classes in /var/www/project/vendor/php-solution/sf-functional-test/src/Tester/ObjectManagerTrait.php on line 62`