### PR TITLE
Add explicitly nullable type.

### DIFF
--- a/src/Fixtures/AbstractFixtureLoader.php
+++ b/src/Fixtures/AbstractFixtureLoader.php
@@ -19,7 +19,7 @@ abstract class AbstractFixtureLoader implements FixtureLoaderInterface
         $this->container = $container;
     }
 
-    public function load(array $files, string $objectManagerName = null): array
+    public function load(array $files, string|null $objectManagerName = null): array
     {
         $fixtureFiles = [];
         foreach ($files as $file) {

--- a/src/Fixtures/Faker/Provider/SymfonyUuidProvider.php
+++ b/src/Fixtures/Faker/Provider/SymfonyUuidProvider.php
@@ -10,7 +10,7 @@ use Symfony\Component\Uid\UuidV4;
 
 final class SymfonyUuidProvider
 {
-    public function uuidv4(string $uuid = null): AbstractUid
+    public function uuidv4(string|null $uuid = null): AbstractUid
     {
         return $uuid ? Uuid::fromString($uuid) : new UuidV4();
     }

--- a/src/Fixtures/Faker/Provider/UUIDProvider.php
+++ b/src/Fixtures/Faker/Provider/UUIDProvider.php
@@ -9,7 +9,7 @@ use Ramsey\Uuid\UuidInterface;
 
 final class UUIDProvider
 {
-    public function uuid4(string $uuid = null): UuidInterface
+    public function uuid4(string|null $uuid = null): UuidInterface
     {
         return $uuid ? Uuid::fromString($uuid) : Uuid::uuid4();
     }

--- a/src/TestCase/ConsoleTestCase.php
+++ b/src/TestCase/ConsoleTestCase.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleTestCase extends AppTestCase
 {
-    public static function runConsoleCommand(string $name, array $parameters = [], Application $consoleApp = null): BufferedOutput
+    public static function runConsoleCommand(string $name, array $parameters = [], Application|null $consoleApp = null): BufferedOutput
     {
         $parameters = array_merge(['command' => $name], $parameters);
         $input = new ArrayInput($parameters);
@@ -32,7 +32,7 @@ class ConsoleTestCase extends AppTestCase
     public static function runCommand(
         InputInterface $input,
         OutputInterface $output,
-        Application $consoleApp = null,
+        Application|null $consoleApp = null,
     ): array {
         $input = self::setDefaultOptions($input);
 

--- a/src/TestCase/Traits/FixturesTrait.php
+++ b/src/TestCase/Traits/FixturesTrait.php
@@ -10,12 +10,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait FixturesTrait
 {
-    protected static function loadOrm(array $files, string $entityManagerName = null): array
+    protected static function loadOrm(array $files, string|null $entityManagerName = null): array
     {
         return (new OrmFixtureLoader(self::getContainer()))->load($files, $entityManagerName);
     }
 
-    protected static function loadOdm(array $files, string $documentManagerName = null): array
+    protected static function loadOdm(array $files, string|null $documentManagerName = null): array
     {
         return (new OdmFixtureLoader(self::getContainer()))->load($files, $documentManagerName);
     }
@@ -27,7 +27,7 @@ trait FixturesTrait
      *
      * @return mixed
      */
-    protected static function load(array $files, string $type = null, string $objectManagerName = null)
+    protected static function load(array $files, string|null $type = null, string $objectManagerName = null)
     {
         switch (true)
         {


### PR DESCRIPTION
Remove messages regarding deprecations in PHP 8.4

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated